### PR TITLE
trading assistant evaluate test

### DIFF
--- a/shell_ai/trading_assistant.py
+++ b/shell_ai/trading_assistant.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Dict
+
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+def evaluate(symbol: str, portfolio: Dict[str, float]) -> Dict[str, float]:
+    """Evaluate a simple trading strategy for the given symbol.
+
+    A very naive strategy is implemented:
+    - Buy one share when the closing price is below 100.
+    - Sell one share when the closing price is above 100.
+
+    Parameters
+    ----------
+    symbol: str
+        The ticker symbol to evaluate.
+    portfolio: dict
+        A mapping with ``cash`` and ``shares`` to be updated in place.
+
+    Returns
+    -------
+    dict
+        The updated portfolio.
+    """
+    data = yf.Ticker(symbol).history(period="1mo")
+
+    for price in data["Close"]:
+        if price < 100 and portfolio.get("cash", 0) >= price:
+            portfolio["cash"] -= price
+            portfolio["shares"] = portfolio.get("shares", 0) + 1
+            logger.info(f"Bought 1 share of {symbol} at {price}")
+        elif price > 100 and portfolio.get("shares", 0) > 0:
+            portfolio["cash"] += price
+            portfolio["shares"] -= 1
+            logger.info(f"Sold 1 share of {symbol} at {price}")
+    return portfolio

--- a/tests/test_trading_assistant.py
+++ b/tests/test_trading_assistant.py
@@ -1,0 +1,29 @@
+import logging
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+
+# Ensure the package root is on the path
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shell_ai import trading_assistant
+
+
+def test_evaluate_updates_portfolio_and_logs(caplog):
+    data = pd.DataFrame({"Close": [90, 110]})
+
+    with patch("shell_ai.trading_assistant.yf.Ticker") as mock_ticker:
+        mock_ticker.return_value.history.return_value = data
+
+        portfolio = {"cash": 1000.0, "shares": 0}
+
+        with caplog.at_level(logging.INFO):
+            trading_assistant.evaluate("AAPL", portfolio)
+
+    assert portfolio == {"cash": 1020.0, "shares": 0}
+
+    messages = caplog.messages
+    assert "Bought 1 share of AAPL at 90" in messages[0]
+    assert "Sold 1 share of AAPL at 110" in messages[1]


### PR DESCRIPTION
## Summary
- add naive trading assistant evaluate function
- test evaluate with synthetic data and mocked yfinance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a5ff160c8333967fdda88474bd41